### PR TITLE
cve-check-tool: native packages for json-glib and hicolor-icon-theme …

### DIFF
--- a/recipes-gnome/hicolor-icon-theme/hicolor-icon-theme_0.13.bbappend
+++ b/recipes-gnome/hicolor-icon-theme/hicolor-icon-theme_0.13.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND = "native"

--- a/recipes-gnome/json-glib/json-glib_1.0.0.bbappend
+++ b/recipes-gnome/json-glib/json-glib_1.0.0.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
…are needed by

cve-check-tool, so added bbappend for these packages in meta-security-isafw layer with
required changes.

Signed-off-by: NaeemKK <naeem_khan@mentor.com>